### PR TITLE
Fix torch models to work with GPU during training

### DIFF
--- a/slingpy/models/torch_model.py
+++ b/slingpy/models/torch_model.py
@@ -151,7 +151,7 @@ class TorchModel(TarfileSerialisationBaseModel):
             if self.preprocess_y_fn is not None:
                 model_labels = self.preprocess_y_fn(model_labels)
 
-            y_pred_i = self.model(model_inputs)
+            y_pred_i = [y.cpu() for y in self.model([m.to(device) for m in model_inputs])]
             loss = self.loss(y_pred_i, model_labels)
             return y_pred_i, loss
 
@@ -209,6 +209,7 @@ class TorchModel(TarfileSerialisationBaseModel):
         info("Resetting to best encountered model at", model_file_path, ".")
 
         # Reset to the best model observed in training.
+        self.model = self.model.cpu()
         self.model.load_state_dict(torch.load(model_file_path))
         shutil.rmtree(temp_dir)  # Cleanup temporary directory after training.
         return self


### PR DESCRIPTION
I'm not sure exactly why these inputs are a list with a single tensor. I assume that this list can change length, but it does not do so in this example. 

Fixes: https://github.com/genedisco/genedisco/issues/3

Note that this does the prediction step with the model on CPU, but this should not cost too much time for the simplicity gained here. 

A better fix would probably be to allow the use to specify the device, but this is much more involved.