### PR TITLE
Fix Slurm processing

### DIFF
--- a/slingpy/apps/run_policies/slurm_single_run_policy.py
+++ b/slingpy/apps/run_policies/slurm_single_run_policy.py
@@ -56,8 +56,14 @@ class SlurmSingleRunPolicy(AbstractRunPolicy):
                                                         project_dir_path=self.app_paths.project_root_directory,
                                                         **kwargs)
 
-        print(contents, end="", file=sys.stdout)  # Redirect to stdout.
-        print(contents, end="", file=sys.stderr, flush=True)  # Redirect to stdout.
+        if contents:
+            contents = '\n'.join('| ' + line for line in contents.split('\n'))
+            print('Job stdout:')
+            print(contents, file=sys.stdout, flush=True)
+        if err_contents:
+            err_contents = '\n'.join('| ' + line for line in err_contents.split('\n'))
+            print('Job stderr:')
+            print(err_contents, file=sys.stderr, flush=True)
         eval_score = MetricDictTools.load_metric_dict(self.app_paths.get_eval_score_dict_path(output_directory))
         test_score = MetricDictTools.load_metric_dict(self.app_paths.get_test_score_dict_path(output_directory))
         model_path = self.app_paths.get_model_file_path(output_directory, TorchModel.get_save_file_extension())

--- a/slingpy/apps/run_policies/slurm_single_run_policy.py
+++ b/slingpy/apps/run_policies/slurm_single_run_policy.py
@@ -55,14 +55,17 @@ class SlurmSingleRunPolicy(AbstractRunPolicy):
                                                         virtualenv_path=virtualenv_path,
                                                         project_dir_path=self.app_paths.project_root_directory,
                                                         **kwargs)
-
+        contents = contents.rstrip()
+        err_contents = err_contents.rstrip()
+        
         if contents:
-            contents = '\n'.join('| ' + line for line in contents.split('\n'))
-            print('Job stdout:')
+            # Indent logs so that they're distinctive from this process's logs
+            contents = '\n'.join('  ' + line for line in contents.split('\n'))
+            print('stdout:')
             print(contents, file=sys.stdout, flush=True)
         if err_contents:
-            err_contents = '\n'.join('| ' + line for line in err_contents.split('\n'))
-            print('Job stderr:')
+            err_contents = '\n'.join('  ' + line for line in err_contents.split('\n'))
+            print('stderr:')
             print(err_contents, file=sys.stderr, flush=True)
         eval_score = MetricDictTools.load_metric_dict(self.app_paths.get_eval_score_dict_path(output_directory))
         test_score = MetricDictTools.load_metric_dict(self.app_paths.get_test_score_dict_path(output_directory))

--- a/slingpy/schedulers/slurm_scheduler.py
+++ b/slingpy/schedulers/slurm_scheduler.py
@@ -33,11 +33,11 @@ class SlurmScheduler(AbstractScheduler):
     def execute(clazz, mem_limit_in_mb: int = 2048, num_cpus: int = 1, virtualenv_path: AnyStr = "",
                 time_limit_hours: int = 0, time_limit_days: int = 1, output_directory: AnyStr = "",
                 project_dir_path: AnyStr = "", exclude: AnyStr = "", **kwargs):
-        if not output_directory and "output_directory" in kwargs:
-            output_directory = kwargs["output_directory"]
         if not output_directory:
             output_directory = tempfile.mkdtemp()
-
+        
+        kwargs = {"output_directory": output_directory, **kwargs}
+        
         logfile = os.path.join(output_directory, "log.txt")
         err_logfile = os.path.join(output_directory, "errlog.txt")
 

--- a/slingpy/utils/metric_dict_tools.py
+++ b/slingpy/utils/metric_dict_tools.py
@@ -82,9 +82,6 @@ class MetricDictTools(object):
         Returns:
             The loaded metric dictionary.
         """
-        if not os.path.isfile(file_path):
-            return None
-
         with open(file_path, "rb") as fp:
             score_dict = pickle.load(fp)
             return score_dict


### PR DESCRIPTION
The main fix is adding `output_directory` back to the `kwargs` used to create the Slurm command. Without an explicit `output_directory`, `TrainApplication` would create a directory in `/tmp/`, save the metrics file there, then delete the directory during cleanup.

The other two changes are for improving debugging if similar issues occur again:
* making the logs from Slurm distinctive (and correctly logging `err_contents`)
* failing immediately if the metrics file isn't there, because as far as I can tell it should always be produced by `AbstractBaseApplication`s, and suppressing the error there just causes other errors downstream.