### PR TITLE
Prevent corruption with interupted/conflicting downloads

### DIFF
--- a/slingpy/utils/download_streamed.py
+++ b/slingpy/utils/download_streamed.py
@@ -15,13 +15,22 @@ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABI
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+import os
+
 import requests
 
-
-def download_streamed(download_url, local_save_file_path, chunk_size=4096):
+def download_streamed(download_url, local_save_file_path, chunk_size=2**20):
     with requests.get(download_url, stream=True) as request:
         request.raise_for_status()
+        tmp_file = str(local_save_file_path) + ".download"
 
-        with open(local_save_file_path, "wb") as fp:
-            for chunk in request.iter_content(chunk_size=chunk_size):
-                fp.write(chunk)
+        try:
+            with open(tmp_file, "wb") as fp:
+                for chunk in request.iter_content(chunk_size=chunk_size):
+                    fp.write(chunk)
+        except:
+            # Clean up partial download if there was an error
+            os.unlink(local_save_file_path)
+            raise
+
+        os.rename(tmp_file, local_save_file_path)

--- a/slingpy/utils/download_streamed.py
+++ b/slingpy/utils/download_streamed.py
@@ -46,11 +46,15 @@ def download_streamed(
                         fp.write(chunk)
             except:
                 # Clean up partial download if there was an error
-                os.unlink(local_save_file_path)
+                try:
+                    os.unlink(tmp_file)
+                except:
+                    pass
                 raise
 
             if skip_if_exists and os.path.exists(local_save_file_path):
-                # Another cluster process already finished the download
-                os.unlink(local_save_file_path)
+                # Another parallel process already successfully finished the
+                # download - keep the earlier copy.
+                os.unlink(tmp_file)
             else:
                 os.rename(tmp_file, local_save_file_path)


### PR DESCRIPTION
* Use a temporary filename so that if a download is interrupted, the partial download won't be mistaken for a full file
* Use an `ILock` to try to minimize parallel downloads of the same file
* For cases when an `ILock` doesn't work (e.g. separate cluster nodes), use a late check to avoid overwriting a faster parallel download's result. There's still a race condition here between `exists` and `rename`, but it's much smaller, and at worst would result in a job failure, not a corruption
* Increase default `chunk_size` to 1MB, because 4kB meant a lot of time spent in Python code, potentially limiting throughput.
* (Potentially breaking change) Add `skip_if_exists=True` arg, so that all existing usages become parallel-safe unless they opt out. I checked our internal codebase and didn't see any cases where we were intentionally overwriting existing files, so hopefully this behavior change is a non-issue
