### PR TITLE
TorchModel for unsupervised learning tasks

### DIFF
--- a/slingpy/models/torch_model.py
+++ b/slingpy/models/torch_model.py
@@ -350,3 +350,239 @@ class TorchModel(TarfileSerialisationBaseModel):
         else:
             instance.collate_fn = None
         return instance
+
+
+    
+    
+class UnsupervisedTorchModel(TarfileSerialisationBaseModel):
+    def __init__(self,
+                 base_module: nn.Module,  # Note: __base_module__ must also implement ArgumentDictionary.
+                 loss: TorchLoss,
+                 preprocess_fn: Optional[Callable[[List[torch.Tensor]], List[torch.Tensor]]] = None,
+                 collate_fn: Optional[Callable] = None,
+                 learning_rate: float = 1e-3,
+                 early_stopping_patience: int = 13,
+                 batch_size: int = 256,
+                 num_epochs: int = 100,
+                 l2_weight: float = 1e-4):
+        super(UnsupervisedTorchModel, self).__init__()
+        self.base_module = base_module
+        self.loss = loss
+        self.preprocess_fn = preprocess_fn
+        self.collate_fn = collate_fn
+        self.model = None
+        self.l2_weight = l2_weight
+        self.num_epochs = num_epochs
+        self.batch_size = batch_size
+        self.learning_rate = learning_rate
+        self.early_stopping_patience = early_stopping_patience
+
+    def get_config(self, deep=True):
+        config = super(TorchModel, self).get_config(deep=deep)
+        del config["base_module"]
+        del config["target_transformer"]
+        del config["loss"]
+        del config["preprocess_x_fn"]
+        return config
+
+    def _make_loader(self, data_source, is_training=False):
+        loader = DataLoader(
+            data_source,
+            batch_size=self.batch_size,
+            collate_fn=self.collate_fn,
+            shuffle=True,
+            sampler=None,
+            batch_sampler=None,
+            num_workers=0,
+            pin_memory=False,
+            drop_last=False,  # Must be set for training in case batch_size == 1 for last batch.
+            timeout=0,
+            worker_init_fn=None,
+        )
+        return loader
+
+    def predict(self):
+        pass
+
+    def fit(self, training_set: AbstractDataSource,
+            validation_set: Optional[AbstractDataSource] = None) -> AbstractBaseModel:
+        if self.model is None:
+            self.model = self.build()
+
+        temp_dir = tempfile.mkdtemp()
+        model_file_path = os.path.join(temp_dir, "model.pt")
+
+        # Save once up front in case training does not converge.
+        torch.save(self.model.state_dict(), model_file_path)
+        training_set = CompositeDataSource([training_set])
+        loader_train = self._make_loader(training_set.to_torch(), is_training=True)
+        loader_val = None
+        if validation_set:
+            validation_set = CompositeDataSource([validation_set])
+            loader_val = self._make_loader(validation_set.to_torch())
+
+        optimizer = optim.Adam(self.model.parameters(), lr=self.learning_rate, weight_decay=self.l2_weight)
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.model = self.model.to(device)
+
+        def get_loss(model_inputs):
+            if self.preprocess_fn is not None:
+                model_inputs = self.preprocess_fn(model_inputs)
+
+            loss = self.loss(model_inputs)
+            return loss
+
+        best_val_loss, num_epochs_no_improvement = float("inf"), 0
+        for epoch in range(self.num_epochs):  # Loop over the dataset multiple times.
+            self.model.train()
+            start_time = time()
+
+            train_loss, num_batches_seen = 0.0, 0
+            for i, batch_data in enumerate(loader_train):
+                optimizer.zero_grad()
+                y_pred_i, loss = get_loss(batch_data)
+
+                loss.backward()
+                optimizer.step()
+                train_loss += loss.item()
+                num_batches_seen += 1
+            train_loss /= num_batches_seen
+
+            val_loss = train_loss
+            if loader_val:
+                self.model.eval()
+                val_loss, num_batches_seen_val = 0.0, 0
+                for batch_data in loader_val:
+                    if self.target_transformer is not None:
+                        labels = self.target_transformer.transform(labels)
+
+                    y_pred_i, loss = get_output_and_loss(batch_data, labels)
+
+                    val_loss += loss
+                    num_batches_seen_val += 1
+                val_loss /= num_batches_seen_val
+
+            if val_loss < best_val_loss:
+                best_val_loss = val_loss
+                torch.save(self.model.state_dict(), model_file_path)
+                num_epochs_no_improvement = 0
+            else:
+                num_epochs_no_improvement += 1
+
+            epoch_duration = time() - start_time
+            info(f"Epoch {epoch+1:d}/{self.num_epochs:d} [{epoch_duration:.2f}s]: "
+                 f"loss = {train_loss:.4f}, val_loss = {val_loss:.4f}")
+
+            if num_epochs_no_improvement >= self.early_stopping_patience:
+                break
+
+        info("Resetting to best encountered model at", model_file_path, ".")
+
+        # Reset to the best model observed in training.
+        self.model = self.model.cpu()
+        self.model.load_state_dict(torch.load(model_file_path))
+        shutil.rmtree(temp_dir)  # Cleanup temporary directory after training.
+        return self
+
+    def build(self) -> nn.Module:
+        available_model_params = PluginTools.get_available_instance_parameters(
+            self.base_module, self.base_module.get_params()
+        )
+        return self.base_module.__class__(**available_model_params)
+
+    @classmethod
+    def get_model_save_file_name(cls) -> AnyStr:
+        return "model.pt"
+
+    @classmethod
+    def get_target_transformer_save_file_name(cls) -> AnyStr:
+        return "target_transformer.pickle"
+
+    @classmethod
+    def get_base_module_save_file_name(cls) -> AnyStr:
+        return "base_module.pickle"
+
+    @classmethod
+    def get_loss_save_file_name(cls) -> AnyStr:
+        return "loss.pickle"
+
+    @classmethod
+    def get_preprocess_x_fn_save_file_name(cls) -> AnyStr:
+        return "preprocess_fn.pickle"
+
+    @classmethod
+    def get_collate_fn_save_file_name(cls) -> AnyStr:
+        return "collate_fn.pickle"
+
+    def save_folder(self, save_folder_path, overwrite=True):
+        self.save_config(
+            save_folder_path,
+            self.get_config(deep=False),
+            self.get_config_file_name(),
+            overwrite,
+            self.__class__
+        )
+        model_save_path = os.path.join(save_folder_path, self.get_model_save_file_name())
+        torch.save(
+            self.model.state_dict(), model_save_path
+        )
+
+        base_module_path = os.path.join(save_folder_path, self.get_base_module_save_file_name())
+        with open(base_module_path, "wb") as save_file:
+            pickle.dump(self.base_module, save_file, pickle.HIGHEST_PROTOCOL)
+
+        loss_save_path = os.path.join(save_folder_path, self.get_loss_save_file_name())
+        with open(loss_save_path, "wb") as save_file:
+            pickle.dump(self.loss, save_file, pickle.HIGHEST_PROTOCOL)
+
+        if self.preprocess_fn is not None:
+            preprocess_fn_path = os.path.join(save_folder_path, self.get_preprocess_fn_save_file_name())
+            with open(preprocess_fn_path, "wb") as save_file:
+                pickle.dump(self.preprocess_fn, save_file, pickle.HIGHEST_PROTOCOL)
+
+        if self.collate_fn is not None:
+            collate_fn_path = os.path.join(save_folder_path, self.get_collate_fn_save_file_name())
+            with open(collate_fn_path, "wb") as save_file:
+                pickle.dump(self.collate_fn, save_file, pickle.HIGHEST_PROTOCOL)
+
+    @classmethod
+    def load_folder(cls: Type[TarfileSerialisationBaseModel], save_folder_path: AnyStr) -> AbstractBaseModel:
+        config = cls.load_config(save_folder_path)
+
+        base_module_path = os.path.join(save_folder_path, cls.get_base_module_save_file_name())
+        with open(base_module_path, "rb") as load_file:
+            base_module = pickle.load(load_file)
+
+        config["base_module"] = base_module
+        config["loss"] = None
+
+        instance = cls(**config)
+        weight_list = torch.load(os.path.join(save_folder_path, cls.get_model_save_file_name()))
+        instance.model = instance.build()
+        instance.model.load_state_dict(weight_list)
+
+        loss_save_path = os.path.join(save_folder_path, cls.get_loss_save_file_name())
+        with open(loss_save_path, "rb") as load_file:
+            instance.loss = pickle.load(load_file)
+
+        target_transformer_save_path = os.path.join(save_folder_path, cls.get_target_transformer_save_file_name())
+        if os.path.isfile(target_transformer_save_path):
+            with open(target_transformer_save_path, "rb") as load_file:
+                instance.target_transformer = pickle.load(load_file)
+        else:
+            instance.target_transformer = None
+
+        preprocess_fn_path = os.path.join(save_folder_path, cls.get_preprocess_fn_save_file_name())
+        if os.path.isfile(preprocess_fn_path):
+            with open(preprocess_fn_path, "rb") as load_file:
+                instance.preprocess_fn = pickle.load(load_file)
+        else:
+            instance.preprocess_fn = None
+
+        collate_fn_path = os.path.join(save_folder_path, cls.get_collate_fn_save_file_name())
+        if os.path.isfile(collate_fn_path):
+            with open(collate_fn_path, "rb") as load_file:
+                instance.collate_fn = pickle.load(load_file)
+        else:
+            instance.collate_fn = None
+        return instance


### PR DESCRIPTION
The current TorchModel is more suitable for supervised learning tasks where there are input and output datasets and the aim is to learn a map from input to output. In unsupervised learning tasks, there is a single dataset and the model is fit on it.
This PR adds another class to torch_model.py called `UnsupervisedTorchModel` to accommodate unsupervised learning applications.